### PR TITLE
Mac OS Software Update

### DIFF
--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -192,22 +192,6 @@ NoSpacePrompt="Please clear up some space by deleting files and then attempt to 
 If this error persists, please contact $ITContact."
 
 ## Functions ##
-powerCheck() {
-    # This is meant to be used when doing CLI update installs.
-    # Updates through the GUI can already determine its own requirements to proceed with
-    # the update process.
-    # Let's wait 5 minutes to see if computer gets plugged into power.
-    for (( i = 1; i <= 5; ++i )); do
-        if [[ "$(/usr/bin/pmset -g ps | /usr/bin/grep "Battery Power")" = "Now drawing from 'Battery Power'" ]] && [[ $i = 5 ]]; then
-            echo "$NoACPower"
-        elif [[ "$(/usr/bin/pmset -g ps | /usr/bin/grep "Battery Power")" = "Now drawing from 'Battery Power'" ]]; then
-            /bin/sleep 60
-        else
-            return 0
-        fi
-    done
-    exit 11
-}
 
 updateGUI() {
     # Update through the GUI
@@ -217,7 +201,6 @@ updateGUI() {
         /bin/launchctl $LMethod $LID /usr/bin/open macappstore://showUpdatesPage
     fi
 }
-
 
 fvStatusCheck() {
     # Check to see if the encryption process is complete
@@ -377,7 +360,6 @@ fi
 # Future Fix: Might want to see if Safari and iTunes are running as sometimes these apps sometimes do not require a restart but do require that the apps be closed
 # A simple stop gap to see if either process is running.
 if [[ "$UpdatesNoRestart" != "" ]] && [[ ! "$(/bin/ps -axc | /usr/bin/grep -e Safari$)" ]] && [[ ! "$(/bin/ps -axc | /usr/bin/grep -e iTunes$)" ]]; then
-    powerCheck
     updateGUI
 fi
 

--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -305,7 +305,6 @@ checkForDisplaySleepAssertions() {
     fi
 }
 
-
 # Function to determine the last activity of softwareupdated
 checkSoftwareUpdateDEndTime(){
     # Last activity for softwareupdated
@@ -357,11 +356,6 @@ fi
 # If we get to this point, there are updates available.
 # If there is no one logged in, exit until the next run.
 if [[ "$LoggedInUser" == "" ]]; then
-    # Commented out as CLI updates no longer work properly.
-    # powerCheck
-    # updateCLI &>/dev/null
-    # updateRestartAction
-
     echo "No user is currently logged in."
     exit 0
 else

--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -148,14 +148,6 @@ else
  > App Store > Updates tab"
 fi
 
-# Message to let user to contact IT
-ContactMsg="There seems to have been an error installing the updates. You can try again $SUGuide
-
-If the error persists, please contact $ITContact."
-
-# Message to display when computer is running off battery
-NoACPower="The computer is currently running off battery and is not plugged into a power source."
-
 # Standard Update Message
 StandardUpdatePrompt="There is a software update available for your Mac that requires a restart. Please click Continue to proceed to Software Update to run this update. If you are unable to start the process at this time, you may choose to postpone by one day.
 
@@ -163,13 +155,8 @@ Attempts left to postpone: $CurrentDeferralValue
 
 You may install macOS software updates at any time $SUGuide"
 
-# Forced Update Message
-ForcedUpdatePrompt="There is a software update available for your Mac that requires you to restart. You have already postponed updates the maximum number of times.
-
-Please save your work and click 'Update' otherwise this message will disappear and the computer will restart automatically."
-
 # Forced Update Message for Apple Silicon
-ForcedUpdatePromptForAS="There is a software update available for your Mac that requires you to restart. You have already postponed updates the maximum number of times.
+ForcedUpdatePrompt="There is a software update available for your Mac that requires you to restart. You have already postponed updates the maximum number of times.
 
 Please save your work and install macOS software updates $SUGuide.
 
@@ -177,19 +164,6 @@ Failure to complete the update will result in the computer shutting down."
 
 # Shutdown Warning Message
 HUDWarningMessage="Please save your work and quit all other applications. This computer will be shutting down soon."
-
-# Message shown when running CLI updates
-HUDMessage="Please save your work and quit all other applications. macOS software updates are being installed in the background. Do not turn off this computer during this time.
-
-This message will go away when updates are complete and closing it will not stop the update process.
-
-If you feel too much time has passed, please contact $ITContact.
-
-"
-#Out of Space Message
-NoSpacePrompt="Please clear up some space by deleting files and then attempt to do the update $SUGuide.
-
-If this error persists, please contact $ITContact."
 
 ## Functions ##
 
@@ -320,7 +294,7 @@ else
             let ForceUpdateScheduledEndTimeInEpoch=$ForceUpdateStartTimeInEpoch+$TimeOutinSecForForcedGUI
             
             # If someone is logged in and they run out of deferrals, prompt them to install updates that require a restart via GUI with warning that shutdown will occur.
-            HELPER=$("$jamfHelper" -windowType utility -icon "$AppleSUIcon" -title "Apple Software Update" -description "$ForcedUpdatePromptForAS" -button1 "Update" -defaultButton 1 -timeout "$TimeOutinSecForForcedGUI" -countdown -alignCountdown "right")
+            HELPER=$("$jamfHelper" -windowType utility -icon "$AppleSUIcon" -title "Apple Software Update" -description "$ForcedUpdatePrompt" -button1 "Update" -defaultButton 1 -timeout "$TimeOutinSecForForcedGUI" -countdown -alignCountdown "right")
             echo "Jamf Helper Exit Code: $HELPER"
             
             # If they click "Update" then take them to the software update preference pane

--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -354,7 +354,7 @@ checkSoftwareUpdateDEndTime(){
     # Add a buffer period of time to last activity end time for softwareupdated
     # There can be 2-3 minute gaps of inactivity 
     # Buffer period = 3 minutes/180 seconds
-    let LastSULogEndTimeInEpochWithBuffer=$LastSULogEndTimeInEpoch+120
+    let LastSULogEndTimeInEpochWithBuffer=$LastSULogEndTimeInEpoch+180
     
     echo "$LastSULogEndTimeInEpochWithBuffer"
 }
@@ -424,7 +424,7 @@ else
             
             exit 0
         else
-            powerCheck
+            # powerCheck
             # We've reached point where updates need to be forced.
             
             # For Apple Silicon Macs and recent versions of MacOS on Intel Macs, behavior needs to be changed:

--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -397,7 +397,7 @@ fi
 # If there is no one logged in, let's try to run the updates.
 if [[ "$LoggedInUser" == "" ]]; then
     powerCheck
-    updateCLI &>/dev/null
+    # updateCLI &>/dev/null # commented out as updateCLI is no longer working.
     updateRestartAction
 else
     checkForDisplaySleepAssertions

--- a/AppleSoftwareUpdate.sh
+++ b/AppleSoftwareUpdate.sh
@@ -394,11 +394,15 @@ if [[ "$UpdatesNoRestart" == "" ]] && [[ "$RestartRequired" == "" ]]; then
 fi
 
 # If we get to this point, there are updates available.
-# If there is no one logged in, let's try to run the updates.
+# If there is no one logged in, exit until the next run.
 if [[ "$LoggedInUser" == "" ]]; then
-    powerCheck
-    # updateCLI &>/dev/null # commented out as updateCLI is no longer working.
-    updateRestartAction
+    # Commented out as CLI updates no longer work properly.
+    # powerCheck
+    # updateCLI &>/dev/null
+    # updateRestartAction
+
+    echo "No user is currently logged in."
+    exit 0
 else
     checkForDisplaySleepAssertions
     


### PR DESCRIPTION
Updated this script to be compatible with Big Sur and later versions of Catalina. Softwareupdate command no longer functions properly when called from a script, so I converted the entire thing to use the Apple Silicon method of popping up the Software Update screen and shutting down if no compliance, rather than attempting to perform the update by itself.